### PR TITLE
Release/0.9.6 -> main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdAIAgentCore",
-            url: "https://github.com/sendbird/sendbird-ai-agent-core-ios/releases/download/0.9.5/SendbirdAIAgentCore.xcframework.zip",
-            checksum: "0624c3900245017046f8065827de4c7feb6107b06efd920fd58fa714f8798311"
+            url: "https://github.com/sendbird/sendbird-ai-agent-core-ios/releases/download/0.9.6/SendbirdAIAgentCore.xcframework.zip",
+            checksum: "89490ab87519997255ca243fe7f6f5b39057e012ac2217c720c08b35146da1c4"
         ),
         .target(
             name: "SendbirdAIAgentCoreTarget",


### PR DESCRIPTION
### BREAKING CHANGES
- **Minimum Requirements**: Xcode 16.3+ (Swift 6.1+) now required

#### What Changed
- Updated to Swift 6.1 to resolve Apple's Swift compiler compatibility issues between versions 6.0 and 6.1
- Addresses module interface incompatibility introduced in Swift 6.1

#### Why This Change?
Apple's Swift 6.1 compiler cannot load modules built with Swift 6.0, even with `BUILD_LIBRARY_FOR_DISTRIBUTION` enabled. This affects users on macOS Sequoia (which requires Xcode 16+) and those using newer Xcode versions.

#### If You See This Error:
```
Failed to build module 'SendbirdAIAgentCore'; 
this SDK is not supported by the compiler
```
**Fix**: Update to Xcode 16.3+, then clean and rebuild your project.